### PR TITLE
fix: Add condition for HotWater delivery

### DIFF
--- a/src/ecam/ecam_wrapper.rs
+++ b/src/ecam/ecam_wrapper.rs
@@ -77,6 +77,7 @@ impl EcamStatus {
             return EcamStatus::Cleaning(state.percentage as usize);
         }
         if state.state == EcamMachineState::MilkPreparation
+            || state.state == EcamMachineState::HotWaterDelivery
             || (state.state == EcamMachineState::ReadyOrDispensing && state.progress != 0)
         {
             return EcamStatus::Busy(state.percentage as usize);


### PR DESCRIPTION
We tried to make a HotWaterDelivery, but the status didn't changed.
We found that this condition was missing in the extract method.